### PR TITLE
Fix B2O formula parenthesization in Chapter 2.2

### DIFF
--- a/src/notes/chapter2/sec2.md
+++ b/src/notes/chapter2/sec2.md
@@ -36,7 +36,7 @@
 
 ### 反码与原码
 
-1. **反码(One's Complement)**: \\(B_{2}O_{\omega}(\boldsymbol{x})=-(x_{\omega-1}·2^{\omega-1}-1)+\sum_{i=0}^{\omega-2}x_{i}·2^{i}  \\) 
+1. **反码(One's Complement)**: \\(B_{2}O_{\omega}(\boldsymbol{x})=-x_{\omega-1}·(2^{\omega-1}-1)+\sum_{i=0}^{\omega-2}x_{i}·2^{i}  \\)
 
 2. **原码(Sign-Magnitude)**: \\(B_{2}S_{\omega}(\boldsymbol{x})=(-1)^{x^{\omega-1}}\sum_{i=0}^{\omega-2}x_{i}·2^{i}  \\) 
 


### PR DESCRIPTION
## Summary
- Fix incorrect parenthesization in the ones' complement (反码) B2O formula in Chapter 2.2
- Changed `-(x_{ω-1}·2^{ω-1}-1)` to `-x_{ω-1}·(2^{ω-1}-1)` so the sign bit weight is correctly `-(2^{ω-1}-1)`

Fixes #47

## Test plan
- [x] Verify the rendered formula matches the correct B2O definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)